### PR TITLE
Cleanup cicd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ vendor*
 tacit-db67b0097365.json
 *~
 tacit-api
-
+*finaldeployment.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-vendor
+vendor*
 *.exe
 tacit-db67b0097365.json
 *~
+tacit-api
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,10 +11,10 @@ build:
     - go build
     - echo $CI_PROJECT_NAME
     - echo $CI_PROJECT_PATH_SLUG
-    - docker build -t us.gcr.io/tacit-196502/myapi:$CI_COMMIT_SHA .
-    - docker tag us.gcr.io/tacit-196502/myapi:$CI_COMMIT_SHA us.gcr.io/tacit-196502/myapi:$CI_COMMIT_REF_NAME
-    - docker push us.gcr.io/tacit-196502/myapi:$CI_COMMIT_SHA
-    - docker push us.gcr.io/tacit-196502/myapi:$CI_COMMIT_REF_NAME
+    - docker build -t us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA .
+    - docker tag us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA us.gcr.io/tacit-196502/myapi:$CI_COMMIT_REF_NAME
+    - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA
+    - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME
     
 deploy:
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,8 @@ build:
     - echo "$DOCKER_PASSWORD" > $jkey
     - gcloud auth activate-service-account --key-file=$jkey
     - gcloud container clusters get-credentials tacit-dev --zone us-central1-a --project tacit-196502
-    - kubectl apply -f ./kube/deployment.yaml
+    - sed 's/{{TAG}}/1.2/g' kube/deployment.yaml > kube/finalDeployment.yaml
+    - kubectl apply -f ./kube/finalDeployment.yaml
     - rm $jkey
     
 deploy_feature: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ build:
     - cp -R . /root/src/tacit-api
     - cd /root/src/tacit-api
     - dep ensure
+    - CGO_ENABLED=0
     - go build
     - docker build -t us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA .
     - docker tag us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,13 +9,12 @@ build:
     - cd /root/src/tacit-api
     - dep ensure
     - go build
-    - echo $CI_PROJECT_ID
     - echo $CI_PROJECT_NAME
     - echo $CI_PROJECT_PATH_SLUG
-    - echo $CI_COMMIT_SHA
-    - echo $CI_COMMIT_REF_NAME
-    - docker build -t us.gcr.io/tacit-196502/myapi:0.0.3 .
-    - docker push us.gcr.io/tacit-196502/myapi:0.0.3
+    - docker build -t us.gcr.io/tacit-196502/myapi:$CI_COMMIT_SHA .
+    - docker tag us.gcr.io/tacit-196502/myapi:$CI_COMMIT_SHA us.gcr.io/tacit-196502/myapi:$CI_COMMIT_REF_NAME
+    - docker push us.gcr.io/tacit-196502/myapi:$CI_COMMIT_SHA
+    - docker push us.gcr.io/tacit-196502/myapi:$CI_COMMIT_REF_NAME
     
 deploy:
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,12 +24,17 @@ build:
     - rm $jkey
     
 deploy_feature: 
+    <<: *deploy_dev
     only:
         - master
         - develop
         
+deploy_non-feature: 
     <<: *deploy_dev
-
+    when: manual
+    except: 
+        - master
+        - develop
     
 
 #package:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,8 +9,6 @@ build:
     - cd /root/src/tacit-api
     - dep ensure
     - go build
-    - echo $CI_PROJECT_NAME
-    - echo $CI_PROJECT_PATH_SLUG
     - docker build -t us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA .
     - docker tag us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME
     - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA
@@ -19,7 +17,6 @@ build:
 deploy:
   script:
     - export jkey=$(mktemp)
-    - echo $jkey
     - echo "$DOCKER_PASSWORD" > $jkey
     - gcloud auth activate-service-account --key-file=$jkey
     - gcloud container clusters get-credentials tacit-dev --zone us-central1-a --project tacit-196502

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 image:
-  name: "us.gcr.io/tacit-196502/go-build:latest"
+  name: "us.gcr.io/tacit-196502/go-build:master"
 
 build:
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ build:
     - echo "$DOCKER_PASSWORD" > $jkey
     - gcloud auth activate-service-account --key-file=$jkey
     - gcloud container clusters get-credentials tacit-dev --zone us-central1-a --project tacit-196502
-    - sed 's/{{TAG}}/1.2/g' kube/deployment.yaml > kube/finalDeployment.yaml
+    - sed "s/{{TAG}}/$CI_COMMIT_REF_NAME/g" kube/deployment.yaml > kube/finalDeployment.yaml
     - kubectl apply -f ./kube/finalDeployment.yaml
     - rm $jkey
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 image:
-  name: "us.gcr.io/tacit-196502/go-build:master"
+  name: "us.gcr.io/tacit-196502/go-build:latest"
 
 build:
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 image:
-  name: "us.gcr.io/tacit-196502/go-build:latest"
+  name: "us.gcr.io/tacit-196502/go-build:master"
 
 build:
   script:
@@ -12,7 +12,7 @@ build:
     - echo $CI_PROJECT_NAME
     - echo $CI_PROJECT_PATH_SLUG
     - docker build -t us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA .
-    - docker tag us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA us.gcr.io/tacit-196502/myapi:$CI_COMMIT_REF_NAME
+    - docker tag us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME
     - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA
     - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,6 @@ build:
     - cd /root/src/tacit-api
     - dep ensure
     - go build
-    - ls -la
     - docker build -t us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA .
     - docker tag us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME
     - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,11 @@ build:
     - cd /root/src/tacit-api
     - dep ensure
     - go build
+    - echo $CI_PROJECT_ID
+    - echo $CI_PROJECT_NAME
+    - echo $CI_PROJECT_PATH_SLUG
+    - echo $CI_COMMIT_SHA
+    - echo $CI_COMMIT_REF_NAME
     - docker build -t us.gcr.io/tacit-196502/myapi:0.0.3 .
     - docker push us.gcr.io/tacit-196502/myapi:0.0.3
     

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ build:
     - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA
     - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME
     
-deploy:
+.deploy_template: &deploy_dev
   script:
     - export jkey=$(mktemp)
     - echo "$DOCKER_PASSWORD" > $jkey
@@ -23,6 +23,15 @@ deploy:
     - kubectl apply -f ./kube/deployment.yaml
     - rm $jkey
     
+deploy_feature: 
+    only:
+        - master
+        - develop
+        
+    <<: *deploy_dev
+
+    
+
 #package:
 #  script:
 #    - docker ps

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,7 @@ build:
     - cp -R . /root/src/tacit-api
     - cd /root/src/tacit-api
     - dep ensure
-    - CGO_ENABLED=0
-    - go build
+    - CGO_ENABLED=0 go build
     - docker build -t us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA .
     - docker tag us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME
     - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ build:
     - cd /root/src/tacit-api
     - dep ensure
     - go build
+    - ls -la
     - docker build -t us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA .
     - docker tag us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_REF_NAME
     - docker push us.gcr.io/tacit-196502/$CI_PROJECT_NAME:$CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,14 +25,14 @@ build:
     
 deploy_feature: 
     <<: *deploy_dev
-    only:
-        - master
-        - develop
-        
-deploy_non-feature: 
-    <<: *deploy_dev
     when: manual
     except: 
+        - master
+        - develop
+
+deploy_develop_master: 
+    <<: *deploy_dev
+    only:
         - master
         - develop
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10.0-stretch
 LABEL maintainer="jjm3333@gmail.com"
 
-COPY TacIt ./src/bin
+COPY tacit-api ./src/bin
 
-CMD ["./bin/TacIt"]
+CMD ["./bin/tacit-api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.10.0-stretch
+FROM alpine:latest
 LABEL maintainer="jjm3333@gmail.com"
 
-COPY tacit-api ./src/bin
+COPY tacit-api /bin/tacit-api
 
-CMD ["./bin/tacit-api"]
+CMD ["/bin/tacit-api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM golang:1.10.0-stretch
 LABEL maintainer="jjm3333@gmail.com"
 
-COPY . ./src/TacIt/
-RUN cd src/TacIt/ && \
-    go install
+COPY TacIt ./src/bin
 
 CMD ["./bin/TacIt"]

--- a/kube/deployment.yaml
+++ b/kube/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: api
     spec:
       containers:
-      - name: myapi
+      - name: api
         image: us.gcr.io/tacit-196502/api:{{TAG}}
         env:
           - name: DB_USER

--- a/kube/deployment.yaml
+++ b/kube/deployment.yaml
@@ -41,14 +41,3 @@ spec:
         - name: cloudsql-instance-credentials
           secret: 
             secretName: cloudsql-instance-credentials
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: api-service
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 8080
-  selector:
-    app: api

--- a/kube/deployment.yaml
+++ b/kube/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: myapi
-        image: us.gcr.io/tacit-196502/myapi:0.0.2.2
+        image: us.gcr.io/tacit-196502/api:{{TAG}}
         env:
           - name: DB_USER
             valueFrom:

--- a/kube/service.yaml
+++ b/kube/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8080
+  selector:
+    app: api


### PR DESCRIPTION
### DONE:
* Update docker image names to be more consistent with project and repo names
* remove build steps from the Docker file so that we only build one artifact
* separate deployment and service kube definitions so that the service is not constantly redeployed
* feature branches can be deployed manually and develop/master will always be deployed
* actually deploy the new image to k8s by inserting the image name into the deployment template